### PR TITLE
Fechar menu no celular ao clicar nos botões

### DIFF
--- a/views/layouts/layout.pug
+++ b/views/layouts/layout.pug
@@ -36,8 +36,8 @@ html(lang="pt-BR")
               a.navbar-item.navbar-on(href="/") Início
               a.navbar-item.navbar-on(href="/bots") Bots
               a.navbar-item.navbar-on(href="/discord") Servidor
-              a.navbar-item.navbar-on(href="#") Documentação
-              a.navbar-item.navbar-on(href="#") Contribuidores
+              a.navbar-item.navbar-on(href="/") Documentação
+              a.navbar-item.navbar-on(href="/") Contribuidores
               a.navbar-item#search-button Buscar
             form.navbar-item#navbar-search(action="/bots")
               input.input(name="search" type="text" placeholder="Qual tipo de bot você deseja encontrar hoje?")


### PR DESCRIPTION
Contribuidores e documentação não fechavam o menu