### PR TITLE
Mostrar prefixo com o nome do bot.

### DIFF
--- a/utils/bot.js
+++ b/utils/bot.js
@@ -7,6 +7,7 @@ function partialBotObject (bot) {
     avatar: formatUrl(id),
     name: bot.username,
     id,
+    prefix: bot.details.prefix,
     status: bot.status,
     description: bot.details.shortDescription,
     votes: bot.votes ? bot.votes.current : -1,
@@ -31,7 +32,6 @@ function botObjectSender (bot) {
       current: bot.votes.current,
       voteslog: bot.votes.voteslog
     }
-
   }
 }
 

--- a/views/staff/bots.pug
+++ b/views/staff/bots.pug
@@ -9,7 +9,7 @@ block content
                         figure.image.is-64x64
                             img.is-rounded(src=bot.avatar)
                     p
-                        strong=bot.name
+                        strong #{bot.name} (#{bot.prefix})
                         br
                         | #{bot.description}
                 nav.level

--- a/views/staff/bots.pug
+++ b/views/staff/bots.pug
@@ -14,7 +14,7 @@ block content
                         | #{bot.description}
                         br
                         strong Prefix:
-                        | #{bot.prefix} 
+                        |  #{bot.prefix} 
                 nav.level
                     .level-left
                         a.button.level-item(href=bot.baseUrl) Página 

--- a/views/staff/bots.pug
+++ b/views/staff/bots.pug
@@ -9,9 +9,12 @@ block content
                         figure.image.is-64x64
                             img.is-rounded(src=bot.avatar)
                     p
-                        strong #{bot.name} (#{bot.prefix})
+                        strong=bot.name
                         br
                         | #{bot.description}
+                        br
+                        strong Prefix:
+                        | #{bot.prefix} 
                 nav.level
                     .level-left
                         a.button.level-item(href=bot.baseUrl) Página 


### PR DESCRIPTION
Mostrar a prefixo do bot do lado do seu nome (como na print)
![image](https://user-images.githubusercontent.com/37600692/112777856-9434c300-9019-11eb-93ce-60568b8ab60b.png)

Mal ai por linhas modificadas desnecessariamente, é meu formatador (standardjs)
